### PR TITLE
feat: add support for adjoints

### DIFF
--- a/src/all.jl
+++ b/src/all.jl
@@ -17,6 +17,7 @@ include("noise.jl")
 include("tensor.jl")
 include("trotter.jl")
 include("vqe.jl")
+include("linalg.jl")
 
 import Base: *
 *(o::QuantumOps, state::sa.SparseVector) = apply(o,state)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1,0 +1,40 @@
+function la.ishermitian(op::Op)
+    if op.mat isa AbstractMatrix && la.ishermitian(op.mat)
+        return true
+    else
+        return false
+    end
+end
+function Base.adjoint(op::Op)
+    matf = op.mat
+    name = op.name * "†"
+
+    if matf isa Function
+        adjmatf = x -> adjoint(matf(x))
+    elseif matf isa la.Adjoint
+        name = op.name[1:end-1]
+        adjmatf = matf.parent
+    else
+        adjmatf = adjoint(matf)
+    end
+    return Op(name, adjmatf, op.qubit, op.target_qubit; type=op.type, noisy=op.noisy, control=op.control)
+end
+
+function Base.adjoint(circ::Circuit)
+    all_layers = circ.layers
+    adjoint_all_layers = []
+
+    while !isempty(all_layers)
+        layer = pop!(all_layers)
+        adjointlayer = map(layer) do op
+            return la.ishermitian(op) ? op : adjoint(op)
+        end
+        push!(adjoint_all_layers, adjointlayer)
+    end
+
+    adjointcirc = deepcopy(circ)
+
+    copy!(adjointcirc.layers, adjoint_all_layers)
+
+    return adjointcirc
+end

--- a/src/struct.jl
+++ b/src/struct.jl
@@ -263,7 +263,7 @@ struct Op <: QuantumOps
 
         new_expand = _get_new_expand(f, qubit, target_qubit, control)
 
-        return new(q,name,matf,qubit,target_qubit,control,noisy,"f",new_expand)
+        return new(q,name,f,qubit,target_qubit,control,noisy,"f",new_expand)
     end
     # Inner-constructor for gates defined from a built-in or matrix 
     function Op(name::String,mat::AbstractMatrix,qubit::Int,target_qubit::Int;type::String="",noisy::Bool=true,control::Int=-2)
@@ -310,6 +310,10 @@ function Op(name::String,qubit::Int,target_qubit::Int;kwargs...)
     mat=gates(name)
 
     return Op(name, mat, qubit, target_qubit; kwargs...)
+end
+# One qubit constructor with matrix or function
+function Op(name::String,matf::Union{Function, AbstractMatrix},qubit::Int; kwargs...)
+    return Op(name, matf, qubit, -1; kwargs...)
 end
 
 function _get_op_num_qubits(qubit::Int, target_qubit::Int, control::Int)

--- a/src/struct.jl
+++ b/src/struct.jl
@@ -246,141 +246,120 @@ Constructs an Op object representing a quantum operation with optional noise.
 struct Op <: QuantumOps
     q::Int
     name::String
-    mat::Union{Matrix,Function}
+    mat::Union{Matrix, la.Adjoint, Function}
     qubit::Int
     target_qubit::Int
     control::Int
     noisy::Bool
     type::String
     expand::Function
-        
-    #one qubit
-    function Op(name::String,qubit::Int;type::String="",noisy::Bool=true,control::Int=-2)
-
-        if qubit==control
-            throw("Qubit must differ from control qubit.")
+    # Inner-constructor for gates defined from a function
+    function Op(name::String,f::Function,qubit::Int,target_qubit::Int;type=nothing,noisy::Bool=true,control::Int=-2)
+        if !isnothing(type)
+            throw(ArgumentError("setting `type` for gates constructed from functions is not supported"))
         end
 
-        mat=gates(name);
-        new_expand(N::Int)=hilbert(N,mat,qubit;control=control)
-        new_expand(sites::Vector{it.Index{Int64}})=control==-2 ? _mat_to_tensor(sites,mat,qubit) : throw("nonlocal tensor is not supported")
+        q = _get_op_num_qubits(qubit, target_qubit, control)
 
-        if _is_it_measurement(name)
+        new_expand = _get_new_expand(f, qubit, target_qubit, control)
+
+        return new(q,name,matf,qubit,target_qubit,control,noisy,"f",new_expand)
+    end
+    # Inner-constructor for gates defined from a built-in or matrix 
+    function Op(name::String,mat::AbstractMatrix,qubit::Int,target_qubit::Int;type::String="",noisy::Bool=true,control::Int=-2)
+
+        q = _get_op_num_qubits(qubit, target_qubit, control)
+
+        sizem = size(mat)
+        if sizem != (2^q, 2^q)
+            throw(ArgumentError("size of matrix $sizem not compatible with $(q)-qubit operation"))
+        end
+
+        if q == 1 && _is_it_measurement(name)
+
             if control!=-2
-                throw("Measurement and control operations are incompatible.")
+                throw(ArgumentError("measurement and control operations are incompatible."))
             end
-            new_expand_M(N::Int)=__measurement_hilbert(N,name,qubit)
-            new_expand_M(sites::Vector{it.Index{Int64}})=control==-2 ? _mat_to_tensor(sites,mat,qubit) : throw("nonlocal tensor is not supported")
 
-            return new(1,name,mat,qubit,-1,-2,false,"🔬",new_expand_M)#noiseless mid-circuit measurement
-        elseif _name_with_arg_bool(name)
-            return new(1,name,mat,qubit,-1,control,noisy,"phase",new_expand)
-        elseif uppercase(name)=="RES"
-            return ifOp("MZ",qubit,"I","X")
+            type = "🔬"
+            noisy = false
+            ismeasure = true
         else
-           return new(1,name,mat,qubit,-1,control,noisy,type,new_expand)
+            _name_with_arg_bool(name) || (type = "phase")
+            ismeasure = false
         end
+
+        new_expand = _get_new_expand(name, mat, qubit, target_qubit, control, ismeasure)
+
+        return new(q,name, mat, qubit,target_qubit,control,noisy,type,new_expand)
     end
-
-    #two qubit
-    function Op(name::String,qubit::Int,target_qubit::Int;type::String="",noisy::Bool=true,control::Int=-2)
-
-        if qubit==control || target_qubit==control
-            throw("qubit or target Qubit must differ from control qubit.")
-        end
-        
-        mat=gates(name);
-        new_expand(N::Int)=hilbert(N,mat,qubit,target_qubit;control=control)
-        new_expand(sites::Vector{it.Index{Int64}})=control==-2 ? _mat_to_tensor(sites,mat,qubit,target_qubit) : throw("nonlocal tensor is not supported")
-
-        if target_qubit>0 && qubit==target_qubit
-            throw("qubit and target qubits cannot be same!")
-        elseif _name_with_arg_bool(name)
-            return new(2,name,mat,qubit,target_qubit,control,noisy,"phase",new_expand)
-        else
-           return new(2,name,mat,qubit,target_qubit,control,noisy,type,new_expand)
-        end
-
-    end
-
-    #one qubit mat
-    function Op(name::String,mat::Matrix,qubit::Int;type::String="",noisy::Bool=true,control::Int=-2)
-
-        if size(mat,1)==2 && qubit!=control
-            q=1
-        else
-            throw("init error. Qubit must differ from control qubit.")
-        end
-
-        new_expand(N::Int)=hilbert(N,mat,qubit;control=control)
-        new_expand(sites::Vector{it.Index{Int64}})=control==-2 ? _mat_to_tensor(sites,mat,qubit) : throw("nonlocal tensor is not supported")
-
-        if _name_with_arg_bool(name)
-            return new(q,name,mat,qubit,-1,control,noisy,"phase",new_expand)
-        else
-            return new(q,name,mat,qubit,-1,control,noisy,type,new_expand)
-        end
-    end
-
-    #one qubit function
-    function Op(name::String,f::Function,qubit::Int;noisy::Bool=true,control::Int=-2)
-
-        # arg_no=BlueTangle._find_argument_number(f)
-        if qubit!=control
-            q=1
-        else
-            throw("init error. Qubit must differ from control qubit.")
-        end
-
-        new_expand(N::Int,pars...)=hilbert(N,f(pars...),qubit;control=control)
-        new_expand(sites::Vector{it.Index{Int64}},pars...)=control==-2 ? _mat_to_tensor(sites,f(pars...),qubit) : throw("nonlocal tensor is not supported")
-        
-        return new(q,name,f,qubit,-1,control,noisy,"f",new_expand)
-    end
-
-
-    #two qubit
-    function Op(name::String,mat::Matrix,qubit::Int,target_qubit::Int;type::String="",noisy::Bool=true,control::Int=-2)
-
-        if size(mat,1)==4 && target_qubit>0 && qubit!=target_qubit && qubit!=control || target_qubit!=control
-            q=2
-        else
-            throw("init error. qubit or target Qubit must differ from control qubit.")
-        end
-
-        new_expand(N::Int)=hilbert(N,mat,qubit,target_qubit;control=control)
-        new_expand(sites::Vector{it.Index{Int64}})=control==-2 ? _mat_to_tensor(sites,mat,qubit,target_qubit) : throw("nonlocal tensor is not supported")
-
-        if _name_with_arg_bool(name)
-            return new(q,name,mat,qubit,target_qubit,control,noisy,"phase",new_expand)
-        else
-           return new(q,name,mat,qubit,target_qubit,control,noisy,type,new_expand)
-        end
-    end
-
-    #two qubit function
-    function Op(name::String,f::Function,qubit::Int,target_qubit::Int;noisy::Bool=true,control::Int=-2)
-
-        # arg_no=BlueTangle._find_argument_number(f)
-
-        if target_qubit>0 && qubit!=target_qubit && qubit!=control || target_qubit!=control
-            q=2
-        else
-            throw("init error. qubit or target Qubit must differ from control qubit.")
-        end
-
-        new_expand(N::Int,pars...)=hilbert(N,f(pars...),qubit,target_qubit;control=control)
-        new_expand(sites::Vector{it.Index{Int64}},pars...)=control==-2 ? _mat_to_tensor(sites,f(pars...),qubit,target_qubit) : throw("nonlocal tensor is not supported")
-
-        return new(q,name,f,qubit,target_qubit,control,noisy,"f",new_expand)
-    end
-    
-    # Op(namePhase::Tuple,qubit::Int)=Op(namePhase[1]*"("*namePhase[2]*")",qubit;type::String="phase",noisy::Bool=true)
-
-    #this is constructor for 2-qubit gates
-    
 end
 
+# One qubit constructor with built-in gate
+function Op(name::String,qubit::Int;kwargs...)
+
+    if uppercase(name)=="RES"
+        return ifOp("MZ",qubit,"I","X")
+    else
+        return Op(name, qubit, -1; kwargs...)
+    end
+end
+# Two qubit constructor with built-in gate
+function Op(name::String,qubit::Int,target_qubit::Int;kwargs...)
+
+    mat=gates(name)
+
+    return Op(name, mat, qubit, target_qubit; kwargs...)
+end
+
+function _get_op_num_qubits(qubit::Int, target_qubit::Int, control::Int)
+    if target_qubit == -1 
+        # single qubit operator
+        if qubit == control
+            throw(ArgumentError("`qubit` must differ from `control` qubit"))
+        else
+            q = 1
+        end
+    else
+        # two qubit operator
+        if qubit == target_qubit
+            throw(ArgumentError("`qubit` and `target_qubit` must differ"))
+        elseif qubit == control && target_qubit == control
+            throw(ArgumentError("either `qubit` or `target_qubit` must differ from `control` qubit"))
+        else
+            q = 2
+        end
+    end
+    return q
+end
+
+function _get_new_expand(name::AbstractString, mat::AbstractMatrix, qubit::Int, target_qubit::Int, control::Int, ismeasure::Bool)
+    function new_expand(N::Int)
+        if target_qubit == -1
+            if ismeasure
+                rv = __measurement_hilbert(N,name,qubit)
+            else
+                rv = hilbert(N,mat,qubit;control=control)
+            end
+        else
+            rv = hilbert(N,mat,qubit,target_qubit;control=control)
+        end
+    end
+    new_expand(sites::Vector{it.Index{Int64}})=control==-2 ? _mat_to_tensor(sites,mat,qubit) : throw("nonlocal tensor is not supported")
+    return new_expand
+end
+function _get_new_expand(f::Function, qubit::Int, target_qubit::Int, control::Int)
+    function new_expand(N::Int,pars...)
+        if target_qubit == -1
+            rv = hilbert(N,f(pars...),qubit;control=control)
+        else
+            rv = hilbert(N,f(pars...),qubit,target_qubit;control=control)
+        end
+        return rv 
+    end
+    new_expand(sites::Vector{it.Index{Int64}},pars...)=control==-2 ? _mat_to_tensor(sites,f(pars...),qubit,target_qubit) : throw("nonlocal tensor is not supported")
+    return new_expand
+end
 
 Op(nameAngle::Vector,qubit::Int;type::String="",noisy::Bool=true,control::Int=-2)=Op("$(nameAngle[1])($(nameAngle[2]...))",qubit;type=type,noisy=noisy,control=control)
 Op(nameAngle::Vector,qubit::Int,target_qubit::Int;type::String="",noisy::Bool=true,control::Int=-2)=Op("$(nameAngle[1])($(nameAngle[2]))",qubit,target_qubit;type=type,noisy=noisy,control=control)


### PR DESCRIPTION
It would be useful to be able to take the adjoint of operators and circuits. 

You should check the code refactoring in `src/struct.jl` as you will have a better understanding of what the various fields of `Op` do, but in theory the changes in this file shouldn't change anything. I made these changes to simplify implementation of the adjoint. 

Also it would be useful to make a dev branch to make pull requested to.  